### PR TITLE
Simply use latest package versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ services: docker
 dist: focal
 
 env:
-  - VERSION=2.16.0
-  - VERSION=2.16.0 VARIANT=alpine
   - VERSION=2.18.0
   - VERSION=2.18.0 VARIANT=alpine
   - VERSION=2.20.0

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -18,12 +18,12 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN apt-get -qq -o=Dpkg::Use-Pty=0 update && \
   apt-get -qq -o=Dpkg::Use-Pty=0 install -y --no-install-recommends \
-    libaio1=0.3.110-3 \
-    xmlstarlet=1.6.1-2 \
-    jq=1.5+dfsg-1.3 \
-    ca-certificates=20161130+nmu1+deb9u1 \
-    wget=1.18-5+deb9u2 \
-    ivy=2.4.0-3 && \
+    libaio1 \
+    xmlstarlet \
+    jq \
+    ca-certificates \
+    wget \
+    ivy && \
   rm -rf /var/lib/apt/lists/*
 
 # Make sure pipes are considered to detemine success, see: https://github.com/hadolint/hadolint/wiki/DL4006
@@ -140,12 +140,12 @@ RUN groupadd -g 1000 -r artemis && useradd -r -u 1000 -g artemis artemis
 
 RUN apt-get -qq -o=Dpkg::Use-Pty=0 update && \
   apt-get -qq -o=Dpkg::Use-Pty=0 install -y --no-install-recommends \
-    libaio1=0.3.110-3 \
-    xmlstarlet=1.6.1-2 \
-    jq=1.5+dfsg-1.3 \
-    gettext-base=0.19.8.1-2+deb9u1 \
-    dumb-init=1.2.0-1 \
-    procps=2:3.3.12-3+deb9u1 && \
+    libaio1 \
+    xmlstarlet \
+    jq \
+    gettext-base \
+    dumb-init \
+    procps && \
   rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder "/opt/apache-artemis-${ACTIVEMQ_ARTEMIS_VERSION}" "/opt/apache-artemis-${ACTIVEMQ_ARTEMIS_VERSION}"

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -18,12 +18,10 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN apt-get -qq -o=Dpkg::Use-Pty=0 update && \
   apt-get -qq -o=Dpkg::Use-Pty=0 install -y --no-install-recommends \
-    libaio1 \
-    xmlstarlet \
-    jq \
-    ca-certificates \
-    wget \
-    ivy && \
+    libaio1=0.3.112-3 \
+    xmlstarlet=1.6.1-2 \
+    jq=1.5+dfsg-2+b1 \
+    ivy=2.4.0-5 && \
   rm -rf /var/lib/apt/lists/*
 
 # Make sure pipes are considered to detemine success, see: https://github.com/hadolint/hadolint/wiki/DL4006
@@ -140,12 +138,12 @@ RUN groupadd -g 1000 -r artemis && useradd -r -u 1000 -g artemis artemis
 
 RUN apt-get -qq -o=Dpkg::Use-Pty=0 update && \
   apt-get -qq -o=Dpkg::Use-Pty=0 install -y --no-install-recommends \
-    libaio1 \
-    xmlstarlet \
-    jq \
-    gettext-base \
-    dumb-init \
-    procps && \
+    libaio1=0.3.112-3 \
+    xmlstarlet=1.6.1-2 \
+    jq=1.5+dfsg-2+b1 \
+    gettext-base=0.19.8.1-9 \
+    dumb-init=1.2.2-1.1 \
+    procps=2:3.3.15-2 && \
   rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder "/opt/apache-artemis-${ACTIVEMQ_ARTEMIS_VERSION}" "/opt/apache-artemis-${ACTIVEMQ_ARTEMIS_VERSION}"

--- a/src/Dockerfile.alpine
+++ b/src/Dockerfile.alpine
@@ -18,12 +18,10 @@ RUN groupadd -g 2000 -r artemis && useradd -u 1000 -r -s /bin/false -g artemis a
 
 RUN apt-get -qq -o=Dpkg::Use-Pty=0 update && \
   apt-get -qq -o=Dpkg::Use-Pty=0 install -y --no-install-recommends \
-    libaio1 \
-    xmlstarlet \
-    jq \
-    ca-certificates \
-    wget \
-    ivy && \
+    libaio1=0.3.112-3 \
+    xmlstarlet=1.6.1-2 \
+    jq=1.5+dfsg-2+b1 \
+    ivy=2.4.0-5 && \
   rm -rf /var/lib/apt/lists/*
 
 # Make sure pipes are considered to detemine success, see: https://github.com/hadolint/hadolint/wiki/DL4006
@@ -144,12 +142,12 @@ RUN addgroup -g 1000 -S artemis && adduser -u 1000 -S -G artemis artemis
 # Sadly this line is likely to fail every so often, see: https://medium.com/@stschindler/the-problem-with-docker-and-alpines-package-pinning-18346593e891
 # Still versions are pinned to maintain some small level of https://reproducible-builds.org/
 RUN apk add --no-cache \
-  libaio \
-  xmlstarlet \
-  jq \
-  dumb-init \
-  sed \
-  gettext
+  libaio=0.3.112-r1 \
+  xmlstarlet=1.6.1-r0 \
+  jq=1.6-r1 \
+  dumb-init=1.2.5-r1 \
+  sed=4.8-r0 \
+  gettext=0.21-r0
 
 COPY --from=builder "/opt/apache-artemis-${ACTIVEMQ_ARTEMIS_VERSION}" "/opt/apache-artemis-${ACTIVEMQ_ARTEMIS_VERSION}"
 COPY --from=builder "/var/lib/artemis" "/var/lib/artemis"

--- a/src/Dockerfile.alpine
+++ b/src/Dockerfile.alpine
@@ -4,7 +4,7 @@
 ## Build Image                                           #
 ##########################################################
 ARG BASE_IMAGE
-FROM openjdk:8u171-jdk-stretch as builder
+FROM openjdk:11-jdk-buster as builder
 LABEL maintainer="Victor Romero <victor.romero@gmail.com>"
 
 ARG ACTIVEMQ_ARTEMIS_VERSION
@@ -18,12 +18,12 @@ RUN groupadd -g 2000 -r artemis && useradd -u 1000 -r -s /bin/false -g artemis a
 
 RUN apt-get -qq -o=Dpkg::Use-Pty=0 update && \
   apt-get -qq -o=Dpkg::Use-Pty=0 install -y --no-install-recommends \
-    libaio1=0.3.110-3 \
-    xmlstarlet=1.6.1-2 \
-    jq=1.5+dfsg-1.3 \
-    ca-certificates=20161130+nmu1+deb9u1 \
-    wget=1.18-5+deb9u2 \
-    ivy=2.4.0-3 && \
+    libaio1 \
+    xmlstarlet \
+    jq \
+    ca-certificates \
+    wget \
+    ivy && \
   rm -rf /var/lib/apt/lists/*
 
 # Make sure pipes are considered to detemine success, see: https://github.com/hadolint/hadolint/wiki/DL4006
@@ -144,12 +144,12 @@ RUN addgroup -g 1000 -S artemis && adduser -u 1000 -S -G artemis artemis
 # Sadly this line is likely to fail every so often, see: https://medium.com/@stschindler/the-problem-with-docker-and-alpines-package-pinning-18346593e891
 # Still versions are pinned to maintain some small level of https://reproducible-builds.org/
 RUN apk add --no-cache \
-  libaio=0.3.111-r0 \
-  xmlstarlet=1.6.1-r0 \
-  jq=1.6-r0 \
-  dumb-init=1.2.2-r1 \
-  sed=4.5-r0 \
-  gettext=0.19.8.1-r4
+  libaio \
+  xmlstarlet \
+  jq \
+  dumb-init \
+  sed \
+  gettext
 
 COPY --from=builder "/opt/apache-artemis-${ACTIVEMQ_ARTEMIS_VERSION}" "/opt/apache-artemis-${ACTIVEMQ_ARTEMIS_VERSION}"
 COPY --from=builder "/var/lib/artemis" "/var/lib/artemis"

--- a/tags.csv
+++ b/tags.csv
@@ -1,7 +1,5 @@
 Repository,Tag,Base Image,Aliases,Dockerfile
-jhatdv/activemq-artemis,2.16.0,openjdk:8u232-jre-stretch,jhatdv/activemq-artemis:2.16-latest,Dockerfile
-jhatdv/activemq-artemis,2.16.0-alpine,openjdk:8u212-jre-alpine3.9,jhatdv/activemq-artemis:2.16-alpine-latest,Dockerfile.alpine
-jhatdv/activemq-artemis,2.18.0,openjdk:8u232-jre-stretch,jhatdv/activemq-artemis:2.18-latest,Dockerfile
-jhatdv/activemq-artemis,2.18.0-alpine,openjdk:8u212-jre-alpine3.9,jhatdv/activemq-artemis:2.18-alpine-latest,Dockerfile.alpine
-jhatdv/activemq-artemis,2.20.0,openjdk:8u232-jre-stretch,jhatdv/activemq-artemis:2.20-latest jhatdv/activemq-artemis:2-latest jhatdv/activemq-artemis:latest,Dockerfile
-jhatdv/activemq-artemis,2.20.0-alpine,openjdk:8u212-jre-alpine3.9,jhatdv/activemq-artemis:2.20-alpine-latest jhatdv/activemq-artemis:2-alpine-latest jhatdv/activemq-artemis:alpine-latest,Dockerfile.alpine
+jhatdv/activemq-artemis,2.18.0,openjdk:11-jdk-buster,jhatdv/activemq-artemis:2.18-latest,Dockerfile
+jhatdv/activemq-artemis,2.18.0-alpine,adoptopenjdk/openjdk11:alpine,jhatdv/activemq-artemis:2.18-alpine-latest,Dockerfile.alpine
+jhatdv/activemq-artemis,2.20.0,openjdk:11-jdk-buster,jhatdv/activemq-artemis:2.20-latest jhatdv/activemq-artemis:2-latest jhatdv/activemq-artemis:latest,Dockerfile
+jhatdv/activemq-artemis,2.20.0-alpine,adoptopenjdk/openjdk11:alpine,jhatdv/activemq-artemis:2.20-alpine-latest jhatdv/activemq-artemis:2-alpine-latest jhatdv/activemq-artemis:alpine-latest,Dockerfile.alpine


### PR DESCRIPTION
Updated base images and uses latest package versions of dependencies